### PR TITLE
fix casting for primitive number fields

### DIFF
--- a/src/main/java/dev/nolij/zson/Zson.java
+++ b/src/main/java/dev/nolij/zson/Zson.java
@@ -289,12 +289,12 @@ public final class Zson {
 			if(type.isPrimitive()) {
 				switch (type.getName()) {
 					case "boolean" -> field.setBoolean(object, (boolean) value);
-					case "short" -> field.setShort(object, (short) (int) value);
-					case "int" -> field.setInt(object, (int) value);
-					case "float" -> field.setFloat(object, (float) (double) value);
-					case "double" -> field.setDouble(object, (double) value);
-					case "long" -> field.setLong(object, (long) value);
-					case "byte" -> field.setByte(object, (byte) (int) value);
+					case "short" -> field.setShort(object, ((Number) value).shortValue());
+					case "int" -> field.setInt(object, ((Number) value).intValue());
+					case "float" -> field.setFloat(object, ((Number) value).floatValue());
+					case "double" -> field.setDouble(object, ((Number) value).doubleValue());
+					case "long" -> field.setLong(object, ((Number) value).longValue());
+					case "byte" -> field.setByte(object, ((Number) value).byteValue());
 					case "char" -> field.setChar(object, (char) value);
 				}
 			} else {

--- a/src/test/java/ZsonTest.java
+++ b/src/test/java/ZsonTest.java
@@ -8,7 +8,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static dev.nolij.zson.Zson.*;
 
+@SuppressWarnings({"unused", "DataFlowIssue", "FieldMayBeFinal"})
 public class ZsonTest {
 	@Test
 	public void testReadWrite() {
@@ -21,14 +23,14 @@ public class ZsonTest {
 		zsonMap.put("name", new ZsonValue("The name of the person\nlook, a second line!", "John Doe"));
 		zsonMap.put("age", new ZsonValue("The age of the person", 30));
 		zsonMap.put("address",  new ZsonValue("The address of the person", Zson.object(
-				Zson.entry("street", "The street of the address", "123 Main St"),
-				Zson.entry("city", "The city of the address", "Springfield"),
-				Zson.entry("state", "The state of the address", "IL"),
-				Zson.entry("zip", "The zip code of the address", 62701)
+				entry("street", "The street of the address", "123 Main St"),
+				entry("city", "The city of the address", "Springfield"),
+				entry("state", "The state of the address", "IL"),
+				entry("zip", "The zip code of the address", 62701)
 		)));
 		zsonMap.put("phoneNumbers",  new ZsonValue("The phone numbers of the person", Zson.object(
-				Zson.entry("home", "217-555-1234"),
-				Zson.entry("cell", "217-555-5678")
+				entry("home", "217-555-1234"),
+				entry("cell", "217-555-5678")
 		)));
 		String json = writer.stringify(zsonMap);
 
@@ -102,12 +104,12 @@ public class ZsonTest {
 		assertEquals(2, arr.get(1));
 		assertEquals(3, arr.get(2));
 
-		Map<String, ZsonValue> obj = Zson.object(
-			Zson.entry("a", 1),
-			Zson.entry("b", "2"),
-			Zson.entry("c", Zson.object(
-				Zson.entry("d", 3),
-				Zson.entry("e", Zson.array(4, 5, 6))
+		Map<String, ZsonValue> obj = object(
+			entry("a", 1),
+			entry("b", "2"),
+			entry("c", object(
+				entry("d", 3),
+				entry("e", array(4, 5, 6))
 			))
 		);
 		assertEquals(obj, map.get("obj").value);
@@ -195,6 +197,17 @@ public class ZsonTest {
 		assertEquals(42, obj.wow);
 	}
 
+	@Test
+	public void testPrimitiveConversion() {
+		Map<String, ZsonValue> json = object(
+			entry("f", 1),
+			entry("d", 1)
+		);
+		AllTypes obj = Zson.map2Obj(json, AllTypes.class);
+		assertEquals(1, obj.f);
+		assertEquals(1, obj.d);
+	}
+
 	public static class TestObject {
 		@ZsonField(comment = "look a comment")
 		public int wow = 42;
@@ -210,6 +223,19 @@ public class ZsonTest {
 		public static final String constant = "wow";
 
 		public TestEnum testEnum = TestEnum.ONE;
+	}
+
+	public static class AllTypes {
+		public boolean bool;
+		public byte b;
+		public short s;
+		public int i;
+		public long l;
+		public float f;
+		public double d;
+		public char c;
+		public String str;
+		public TestEnum e;
 	}
 
 	public enum TestEnum {

--- a/src/test/java/ZsonTest.java
+++ b/src/test/java/ZsonTest.java
@@ -199,13 +199,16 @@ public class ZsonTest {
 
 	@Test
 	public void testPrimitiveConversion() {
-		Map<String, ZsonValue> json = object(
-			entry("f", 1),
-			entry("d", 1)
-		);
+		Map<String, ZsonValue> json = Zson.parseString("""
+		{
+			"f": 1,
+			"d": 2,
+		}""");
+		assertEquals(1, json.get("f").value);
+		assertEquals(2, json.get("d").value);
 		AllTypes obj = Zson.map2Obj(json, AllTypes.class);
 		assertEquals(1, obj.f);
-		assertEquals(1, obj.d);
+		assertEquals(2, obj.d);
 	}
 
 	public static class TestObject {


### PR DESCRIPTION
`java.lang.Number` saves the day once more

I accidentally did the pr the wrong way so now we have https://github.com/rhysdh540/ZSON/pull/1 to laugh at