### PR TITLE
improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ build/
 .idea/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/**/build/
-*.json5
 .DS_Store

--- a/spec.json5
+++ b/spec.json5
@@ -1,0 +1,12 @@
+{
+  // comments
+  unquoted: 'and you can quote me on that',
+  singleQuotes: 'I can use "double quotes" here',
+  lineBreaks: "Look, Mom! \
+No \\n's!",
+  hexadecimal: 0xdecaf,
+  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
+  positiveSign: +1,
+  trailingComma: 'in objects', andIn: ['arrays',],
+  "backwardsCompatible": "with JSON",
+}

--- a/src/main/java/dev/nolij/zson/Zson.java
+++ b/src/main/java/dev/nolij/zson/Zson.java
@@ -70,6 +70,16 @@ public final class Zson {
 		return list;
 	}
 
+	public static <E extends Enum<E>> void convertEnum(Map<String, ZsonValue> json, String key, Class<E> enumClass) {
+		ZsonValue value = json.get(key);
+		if(value == null) return;
+		if(value.value instanceof String s) {
+			json.put(key, new ZsonValue(value.comment, Enum.valueOf(enumClass, s)));
+		} else if(!enumClass.isInstance(value.value)) {
+			throw new IllegalArgumentException("Expected string, got " + value.value);
+		}
+	}
+
 	/**
 	 * "Un-escapes" a string by replacing escape sequences with their actual characters.
 	 * @param string the string to un-escape. May be null.
@@ -298,11 +308,11 @@ public final class Zson {
 					case "char" -> field.setChar(object, (char) value);
 				}
 			} else {
-				if(type.isEnum()) {
-					field.set(object, Enum.valueOf((Class<Enum>) type, (String) value));
-				} else {
-					field.set(object, type.cast(value));
+				Object finalValue = value;
+				if (type.isEnum() && value instanceof String) {
+					finalValue = Enum.valueOf((Class<Enum>) type, (String) value);
 				}
+				field.set(object, finalValue);
 			}
 		} catch (Exception e) {
 			throw new AssertionError(

--- a/src/main/java/dev/nolij/zson/Zson.java
+++ b/src/main/java/dev/nolij/zson/Zson.java
@@ -569,7 +569,7 @@ public final class Zson {
 	 * @return The parsed identifier
 	 * @throws IOException If an I/O error occurs
 	 */
-	// TODO: handle multi-character escapes and comments between the identifier and the colon (like "a/*comment*/:1")
+	// TODO: handle multi-character escapes
 	@Contract(mutates = "param1")
 	private static String parseIdentifier(Reader input, int start) throws IOException {
 		var output = new StringBuilder();

--- a/src/main/java/dev/nolij/zson/Zson.java
+++ b/src/main/java/dev/nolij/zson/Zson.java
@@ -1,5 +1,6 @@
 package dev.nolij.zson;
 
+import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -10,13 +11,21 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.math.BigInteger;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
-import java.util.Map.Entry;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import java.math.BigInteger;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings({"deprecation", "UnstableApiUsage"})
 public final class Zson {
@@ -50,7 +59,7 @@ public final class Zson {
 	@Contract("_ -> new")
 	public static Map<String, ZsonValue> object(@NotNull Map.Entry<String, ZsonValue>... entries) {
 		Map<String, ZsonValue> map = new LinkedHashMap<>();
-		for (Entry<String, ZsonValue> e : entries) {
+		for (Map.Entry<String, ZsonValue> e : entries) {
 			map.put(e.getKey(), e.getValue());
 		}
 		return map;
@@ -349,7 +358,7 @@ public final class Zson {
 	 */
 	@Nullable
 	@Contract(pure = true)
-	public static <T> T parseString(@NotNull String serialized) {
+	public static <T> T parseString(@NotNull @Language("json5") String serialized) {
 		try {
 			return parse(new StringReader(serialized));
 		} catch (IOException e) {

--- a/src/main/java/dev/nolij/zson/ZsonValue.java
+++ b/src/main/java/dev/nolij/zson/ZsonValue.java
@@ -32,7 +32,7 @@ public final class ZsonValue {
 
 	@Override
 	public int hashCode() {
-		return value == null ? 0 : value.hashCode();
+		return Objects.hashCode(value);
 	}
 
 	@Override

--- a/src/test/java/ZsonTest.java
+++ b/src/test/java/ZsonTest.java
@@ -262,6 +262,34 @@ public class ZsonTest {
 		)));
 	}
 
+	@Test
+	public void testUnquotedKeys() {
+		TestObject obj = new TestObject();
+		obj.testEnum = TestEnum.TWO;
+		Map<String, ZsonValue> json = obj2Map(obj);
+		String expected = """
+		{
+			// look a comment
+			wow: 42,
+			such: "amaze",
+			very: true,
+			constant: "wow",
+			testEnum: "TWO",
+		}""";
+
+		String actual = new Zson().withQuoteKeys(false).stringify(json);
+
+		assertEquals(expected, actual);
+
+		Map<String, ZsonValue> parsed = parseString(actual);
+		convertEnum(parsed, "testEnum", TestEnum.class);
+		assertEquals(json, parsed);
+
+		TestObject obj2 = map2Obj(parsed, TestObject.class);
+
+		assertEquals(obj, obj2);
+	}
+
 	public static class TestObject {
 		@ZsonField(comment = "look a comment")
 		public int wow = 42;
@@ -277,6 +305,17 @@ public class ZsonTest {
 		public static final String constant = "wow";
 
 		public TestEnum testEnum = TestEnum.ONE;
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) return true;
+			if (!(obj instanceof TestObject other)) return false;
+			return wow == other.wow
+				   && such.equals(other.such)
+				   && very == other.very
+				   && pi == other.pi
+				   && testEnum == other.testEnum;
+		}
 	}
 
 	public static class AllTypes {

--- a/src/test/java/ZsonTest.java
+++ b/src/test/java/ZsonTest.java
@@ -256,6 +256,10 @@ public class ZsonTest {
 
 		json = "/**/[/**/1/**/,\"str\"  ,/**/\t7]";
 		assertEquals(parseString(json), array(1, "str", 7));
+
+		assertThrows(IllegalArgumentException.class, () -> new Zson().stringify(object(
+			entry(null, 1)
+		)));
 	}
 
 	public static class TestObject {

--- a/src/test/java/ZsonTest.java
+++ b/src/test/java/ZsonTest.java
@@ -211,6 +211,43 @@ public class ZsonTest {
 		assertEquals(2, obj.d);
 	}
 
+	@Test
+	public void testFunkyFormatting() {
+		String json = """
+		{"hmm": true,
+											"constant":false,a:   "seven"}""";
+
+		assertEquals(parseString(json), object(
+			entry("hmm", true),
+			entry("constant", false),
+			entry("a", "seven")
+		));
+
+		json = """
+				{
+			unquoted: "key",
+			"num": 2.2,
+		\\bee\\f: "yum" // comment
+		 }""";
+
+		assertEquals(parseString(json), object(
+			entry("unquoted", "key"),
+			entry("num", 2.2),
+			entry("\bee\f", "yum")
+		));
+
+		json = "{a:1,b:2,c:[3,4,5],d:{e:6,f:7}}";
+		assertEquals(parseString(json), object(
+			entry("a", 1),
+			entry("b", 2),
+			entry("c", array(3, 4, 5)),
+			entry("d", object(
+				entry("e", 6),
+				entry("f", 7)
+			))
+		));
+	}
+
 	public static class TestObject {
 		@ZsonField(comment = "look a comment")
 		public int wow = 42;

--- a/src/test/java/ZsonTest.java
+++ b/src/test/java/ZsonTest.java
@@ -246,6 +246,16 @@ public class ZsonTest {
 				entry("f", 7)
 			))
 		));
+
+		json = "{/*comment *//*comment */ a  :/*comment */1/*comment */, b/*comment */ : 2 }//comment";
+
+		assertEquals(parseString(json), object(
+			entry("a", 1),
+			entry("b", 2)
+		));
+
+		json = "/**/[/**/1/**/,\"str\"  ,/**/\t7]";
+		assertEquals(parseString(json), array(1, "str", 7));
 	}
 
 	public static class TestObject {

--- a/src/test/java/ZsonTest.java
+++ b/src/test/java/ZsonTest.java
@@ -4,6 +4,8 @@ import dev.nolij.zson.ZsonField;
 import dev.nolij.zson.Zson;
 import dev.nolij.zson.ZsonValue;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -12,6 +14,26 @@ import static dev.nolij.zson.Zson.*;
 
 @SuppressWarnings({"unused", "DataFlowIssue", "FieldMayBeFinal"})
 public class ZsonTest {
+
+	@Test
+	public void json5Spec() throws IOException {
+
+		Map<String, ZsonValue> map = parseFile(Path.of("spec.json5"));
+
+		assertEquals(map, object(
+			entry("unquoted", "and you can quote me on that"),
+			entry("singleQuotes", "I can use \"double quotes\" here"),
+			entry("lineBreaks", "Look, Mom! \nNo \\n's!"),
+			entry("hexadecimal", 0xdecaf),
+			entry("leadingDecimalPoint", .8675309),
+			entry("andTrailing", 8675309.),
+			entry("positiveSign", +1),
+			entry("trailingComma", "in objects"),
+			entry("andIn", array("arrays")),
+			entry("backwardsCompatible", "with JSON")
+		));
+	}
+
 	@Test
 	public void testReadWrite() {
 		Zson writer = new Zson()


### PR DESCRIPTION
- parse unquoted keys (mostly) to spec
- strengthen enum support
  - adds a method `Zson.convertEnum(Map json, String key, Class<Enum> clazz)` to convert `key` in `json` from a `String` to an instance of `clazz`